### PR TITLE
[Fix] Make docker workflow more flexible to inputs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: "oriedge"
         type: string
+      dockerFile:
+        description: "path to the Dockerfile"
+        required: false
+        default: ""
+        type: string
       imageName:
         description: "name of the docker image to be built ({repo}/{name}:{version})"
         required: true
@@ -123,6 +128,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ inputs.buildContext }}
+          file: ${{ inputs.dockerFile }}
           build-args: ${{ env.BUILD_ARGS }}
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ on:
       dockerImageMode:
         description: "mode from which the docker image should be created from (custom, branch_ref, chart_ref)"
         required: false
-        default: "chart_version"
+        default: "chart_ref"
         type: string
       imageName:
         description: "name of the docker image to be built"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,7 @@ jobs:
         if: ${{ env.IMAGE_VERSION == '' }}
         run: |
           echo "[debug] inputs.dockerImageMode: ${{ inputs.dockerImageMode }}"
-          echo "[debug] inputs.dockerImage: ${{ inputs.dockerImage }}"
+          echo "[debug] inputs.imageVersion: ${{ inputs.imageVersion }}"
           echo "[debug] inputs.chartPath: ${{ inputs.chartPath }}"
           echo "[error] env.IMAGE_VERSION is empty"
           exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       chartPath:
-        description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml (used to generate imageVersion variable in chart_version mode)"
+        description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml (used by dockerImageMode 'chart_ref')"
         required: false
         type: string
       dockerRegistry:
@@ -23,7 +23,7 @@ on:
         default: ""
         type: string
       dockerImageMode:
-        description: "mode from which the docker image should be created from (custom, chart_version, branch_ref)"
+        description: "mode from which the docker image should be created from (custom, branch_ref, chart_ref)"
         required: false
         default: "chart_version"
         type: string
@@ -42,7 +42,7 @@ on:
         required: false
         type: string
       push:
-        description: ""
+        description: "the flag indicating if the image should be pushed to the registry or not"
         default: true
         required: false
         type: boolean
@@ -59,18 +59,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to quay.io Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ inputs.dockerRegistry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -79,21 +79,24 @@ jobs:
       - name: Generate image version (CUSTOM)
         if: ${{ inputs.dockerImageMode == 'custom' }}
         run: |
-          echo "IMAGE_VERSION=${{ inputs.dockerImage }}" >> $GITHUB_ENV
+          IMAGE_VERSION=${{ inputs.dockerImage }}
           echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
 
       - name: Generate image version (CHART_REF)
         if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
+          IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
           echo "CHART_PATH=${{ inputs.chartPath }}"
-          echo "IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')" >> $GITHUB_ENV
           echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
 
       - name: Generate image version (BRANCH_REF)
         if: ${{ inputs.dockerImageMode == 'branch_ref' }}
         run: |
-          echo "IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+          IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
           echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
 
       - name: Validate image version
         if: ${{ env.IMAGE_VERSION == '' }}
@@ -105,7 +108,7 @@ jobs:
           exit 1
 
       - name: Build and push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ inputs.buildContext }}
           build-args: version=${{ env.IMAGE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,7 +107,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ inputs.buildContext }}
-          build-args: version=${{ env.CHART_VERSION }}
+          build-args: version=${{ env.IMAGE_VERSION }}
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
           tags: ${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}:${{ env.IMAGE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,14 +3,29 @@ name: Docker build and push
 on:
   workflow_call:
     inputs:
-      dockerImageMode:
-        description: "mode from which the docker image should be created from (branch_ref, chart_ref, custom)"
+      buildArgs:
+        description: "docker build args (see --build-arg in docker docs)"
+        default: ""
         required: false
-        default: "chart_ref"
+        type: string
+      buildContext:
+        description: "docker build context"
+        default: "."
+        required: false
         type: string
       chartPath:
         description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml (used by dockerImageMode 'chart_ref')"
         required: false
+        type: string
+      dockerFile:
+        description: "path to the Dockerfile"
+        required: false
+        default: ""
+        type: string
+      dockerImageMode:
+        description: "mode from which the docker image should be created from (branch_ref, chart_ref, custom)"
+        required: false
+        default: "chart_ref"
         type: string
       dockerRegistry:
         description: "name of the docker registry"
@@ -22,11 +37,6 @@ on:
         required: false
         default: "oriedge"
         type: string
-      dockerFile:
-        description: "path to the Dockerfile"
-        required: false
-        default: ""
-        type: string
       imageName:
         description: "name of the docker image to be built ({repo}/{name}:{version})"
         required: true
@@ -35,16 +45,6 @@ on:
         description: "version of the docker image to be built ({repo}/{name}:{version}) (Overrides image mode)"
         required: false
         default: ""
-        type: string
-      buildContext:
-        description: "docker build context"
-        default: "."
-        required: false
-        type: string
-      buildArgs:
-        description: "docker build args (see --build-arg in docker docs)"
-        default: ""
-        required: false
         type: string
       platforms:
         description: "the list of platforms/architectures to create docker images for"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,12 +115,19 @@ jobs:
 
       - name: Generate build args
         run: |
-          BUILD_ARGS=$(echo ${inputs.buildArgs} | sed 's/^ *//g')
-          if [[ ${BUILD_ARGS::1} != "|" ]]; then
-            BUILD_ARGS="|\n${BUILD_ARGS}"
+          BUILD_ARGS=$(echo "${{ inputs.buildArgs }}" | sed 's/^ *//g')
+          if [ -z "${BUILD_ARGS}" ]; then
+            BUILD_ARGS="|
+              version=${{ env.IMAGE_VERSION }}
+            "
+          else if [ "${BUILD_ARGS::1}" != "|" ]; then
+            BUILD_ARGS="|
+              ${BUILD_ARGS}
+              version=${{ env.IMAGE_VERSION }}
+            "
+          else
+            BUILD_ARGS+="\n version=${env.IMAGE_VERSION}"
           fi
-          BUILD_ARGS+="\n"
-          BUILD_ARGS+="version=${{ env.IMAGE_VERSION }}"
           echo "BUILD_ARGS=${BUILD_ARGS}"
           echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,25 +77,25 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Generate image version (CUSTOM)
-        if: ${{ inputs.dockerImageMode == "custom" }}
+        if: ${{ inputs.dockerImageMode == 'custom' }}
         run: |
           echo "IMAGE_VERSION=${{ inputs.dockerImage }}" >> $GITHUB_ENV
 
       - name: Generate image version (CHART_REF)
-        if: ${{ inputs.dockerImageMode == "chart_ref" }}
+        if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
           echo "CHART_PATH=${{ inputs.chartPath }}"
           export IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
           echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
 
       - name: Generate image version (BRANCH_REF)
-        if: ${{ inputs.dockerImageMode == "branch_ref" }}
+        if: ${{ inputs.dockerImageMode == 'branch_ref' }}
         run: |
           export IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
           echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
 
       - name: Validate image version
-        if: ${{ env.IMAGE_VERSION == "" }}
+        if: ${{ env.IMAGE_VERSION == '' }}
         run: |
           echo "[debug] inputs.dockerImageMode: ${{ inputs.dockerImageMode }}"
           echo "[debug] inputs.dockerImage: ${{ inputs.dockerImage }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,11 @@ name: Docker build and push
 on:
   workflow_call:
     inputs:
+      dockerImageMode:
+        description: "mode from which the docker image should be created from (branch_ref, chart_ref, custom)"
+        required: false
+        default: "chart_ref"
+        type: string
       chartPath:
         description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml (used by dockerImageMode 'chart_ref')"
         required: false
@@ -17,17 +22,12 @@ on:
         required: false
         default: "oriedge"
         type: string
-      dockerImageMode:
-        description: "mode from which the docker image should be created from (branch_ref, chart_ref)"
-        required: false
-        default: "chart_ref"
-        type: string
       imageName:
         description: "name of the docker image to be built ({repo}/{name}:{version})"
         required: true
         type: string
       imageVersion:
-        description: "version of the docker image to be built ({repo}/{name}:{version})"
+        description: "version of the docker image to be built ({repo}/{name}:{version}) (Overrides image mode)"
         required: false
         default: ""
         type: string

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,19 +17,19 @@ on:
         required: false
         default: "oriedge"
         type: string
-      dockerImage:
-        description: "name of the docker image (over-rides generated image names)"
-        required: false
-        default: ""
-        type: string
       dockerImageMode:
-        description: "mode from which the docker image should be created from (custom, branch_ref, chart_ref)"
+        description: "mode from which the docker image should be created from (branch_ref, chart_ref)"
         required: false
         default: "chart_ref"
         type: string
       imageName:
-        description: "name of the docker image to be built"
+        description: "name of the docker image to be built ({repo}/{name}:{version})"
         required: true
+        type: string
+      imageVersion:
+        description: "version of the docker image to be built ({repo}/{name}:{version})"
+        required: false
+        default: ""
         type: string
       buildContext:
         description: "docker build context"
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
       platforms:
-        description: "the list of platforms/architectures to created images for"
+        description: "the list of platforms/architectures to create docker images for"
         default: "linux/amd64,linux/arm64"
         required: false
         type: string
@@ -76,17 +76,10 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Generate image version (CUSTOM)
-        if: ${{ inputs.dockerImageMode == 'custom' }}
-        run: |
-          IMAGE_VERSION="${{ inputs.dockerImage }}"
-          echo "IMAGE_VERSION=${IMAGE_VERSION}"
-          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
-
       - name: Generate image version (CHART_REF)
         if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
-          if [[ -z ${{ inputs.chartPath }} ]]; then
+          if [[ -z "${{ inputs.chartPath }}" ]]; then
             echo "inputs.chartPath must be set in dockerImageMode 'chart_ref'"
             exit 1
           fi
@@ -99,6 +92,13 @@ jobs:
         if: ${{ inputs.dockerImageMode == 'branch_ref' }}
         run: |
           IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
+          echo "IMAGE_VERSION=${IMAGE_VERSION}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
+
+      - name: Generate image version (CUSTOM)
+        if: ${{ inputs.imageVersion != '' }}
+        run: |
+          IMAGE_VERSION="${{ inputs.imageVersion }}"
           echo "IMAGE_VERSION=${IMAGE_VERSION}"
           echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           BUILD_ARGS="version=${{ env.IMAGE_VERSION }}"
           if [[ ! -z "${{ inputs.buildArgs }}" ]]; then
-            BUILD_ARGS+=",${{ inputs.buildArgs }}"
+            BUILD_ARGS="${{ inputs.buildArgs }}" 
           fi
           echo "BUILD_ARGS=${BUILD_ARGS}"
           echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,19 +115,7 @@ jobs:
 
       - name: Generate build args
         run: |
-          BUILD_ARGS=$(echo "${{ inputs.buildArgs }}" | sed 's/^ *//g')
-          if [ -z "${BUILD_ARGS}" ]; then
-            BUILD_ARGS="|
-              version=${{ env.IMAGE_VERSION }}
-            "
-          else if [ "${BUILD_ARGS::1}" != "|" ]; then
-            BUILD_ARGS="|
-              ${BUILD_ARGS}
-              version=${{ env.IMAGE_VERSION }}
-            "
-          else
-            BUILD_ARGS+="\n version=${env.IMAGE_VERSION}"
-          fi
+          BUILD_ARGS=$(echo "${{ inputs.buildArgs }}" | sed "s/version=version/version=${{ env.IMAGE_VERSION }}/g")
           echo "BUILD_ARGS=${BUILD_ARGS}"
           echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,24 +79,24 @@ jobs:
       - name: Generate image version (CUSTOM)
         if: ${{ inputs.dockerImageMode == 'custom' }}
         run: |
-          IMAGE_VERSION=${{ inputs.dockerImage }}
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
+          IMAGE_VERSION="${{ inputs.dockerImage }}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
 
       - name: Generate image version (CHART_REF)
         if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
           IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
           echo "CHART_PATH=${{ inputs.chartPath }}"
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${IMAGE_VERSION}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
 
       - name: Generate image version (BRANCH_REF)
         if: ${{ inputs.dockerImageMode == 'branch_ref' }}
         run: |
           IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
-          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${IMAGE_VERSION}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
 
       - name: Validate image version
         if: ${{ env.IMAGE_VERSION == '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
     inputs:
       chartPath:
-        description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml"
-        required: true
+        description: "helm Chart.yaml path e.g. charts/yourapp/Chart.yaml (used to generate imageVersion variable in chart_version mode)"
+        required: false
         type: string
       dockerRegistry:
         description: "name of the docker registry"
@@ -17,6 +17,16 @@ on:
         required: false
         default: "oriedge"
         type: string
+      dockerImage:
+        description: "name of the docker image (over-rides generated image names)"
+        required: false
+        default: ""
+        type: string
+      dockerImageMode:
+        description: "mode from which the docker image should be created from (custom, chart_version, branch_ref)"
+        required: false
+        default: "chart_version"
+        type: string
       imageName:
         description: "name of the docker image to be built"
         required: true
@@ -26,6 +36,16 @@ on:
         default: "."
         required: false
         type: string
+      platforms:
+        description: "the list of platforms/architectures to created images for"
+        default: "linux/amd64,linux/arm64"
+        required: false
+        type: string
+      push:
+        description: ""
+        default: true
+        required: false
+        type: boolean
     secrets:
       REGISTRY_USERNAME:
         description: "docker registry username"
@@ -43,9 +63,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get helm chart version
-        run: echo "CHART_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')" >> $GITHUB_ENV
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -59,11 +76,38 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Build docker image version
+        shell: bash
+        run: |
+          echo "[debug] dockerImage: ${{ inputs.dockerImage }}"
+          echo "[debug] dockerImageMode: ${{ inputs.dockerImageMode }}"
+          echo "[debug] chartPath: ${{ inputs.chartPath }}"
+          if [ -z "${{ inputs.dockerImage }}" ]
+          then
+            export IMAGE_VERSION="${{ inputs.dockerImage }}"
+          else if [ "${{ inputs.dockerImageMode }}" = "chart_version" ] && [ ! -z "${{ inputs.chartPath }}" ]
+          then
+            export IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
+          else if [ "${{ inputs.dockerImageMode }}" =  "branch_ref" ]
+          then
+            export IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
+          else
+            echo "Invalid IMAGE_VERSION configuration"
+            exit 1
+          fi
+          echo "[debug] IMAGE_VERSION=${{ IMAGE_VERSION }}"
+          if [ -z "${{ IMAGE_VERSION }}" ]
+          then
+            echo "[error] image version is empty"
+            exit 1
+          fi
+          echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
+
       - name: Build and push image
         uses: docker/build-push-action@v2
         with:
           context: ${{ inputs.buildContext }}
           build-args: version=${{ env.CHART_VERSION }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}:${{ env.CHART_VERSION }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          tags: ${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}:${{ env.IMAGE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,11 @@ on:
         default: "."
         required: false
         type: string
+      buildArgs:
+        description: "docker build args (see --build-arg in docker docs)"
+        default: ""
+        required: false
+        type: string
       platforms:
         description: "the list of platforms/architectures to create docker images for"
         default: "linux/amd64,linux/arm64"
@@ -105,17 +110,23 @@ jobs:
       - name: Validate image version
         if: ${{ env.IMAGE_VERSION == '' }}
         run: |
-          echo "[debug] inputs.dockerImageMode: ${{ inputs.dockerImageMode }}"
-          echo "[debug] inputs.imageVersion: ${{ inputs.imageVersion }}"
-          echo "[debug] inputs.chartPath: ${{ inputs.chartPath }}"
-          echo "[error] env.IMAGE_VERSION is empty"
+          echo "ERROR: env.IMAGE_VERSION is empty"
           exit 1
+
+      - name: Generate build args
+        run: |
+          BUILD_ARGS="version=${{ env.IMAGE_VERSION }}"
+          if [[ ! -z "${{ inputs.buildArgs }}" ]]; then
+            BUILD_ARGS+=",${{ inputs.buildArgs }}"
+          fi
+          echo "BUILD_ARGS=${BUILD_ARGS}"
+          echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV
 
       - name: Build and push image
         uses: docker/build-push-action@v3
         with:
           context: ${{ inputs.buildContext }}
-          build-args: version=${{ env.IMAGE_VERSION }}
+          build-args: ${{ env.BUILD_ARGS }}
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
           tags: ${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}:${{ env.IMAGE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,19 +80,20 @@ jobs:
         if: ${{ inputs.dockerImageMode == 'custom' }}
         run: |
           echo "IMAGE_VERSION=${{ inputs.dockerImage }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
 
       - name: Generate image version (CHART_REF)
         if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
           echo "CHART_PATH=${{ inputs.chartPath }}"
-          export IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
-          echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
 
       - name: Generate image version (BRANCH_REF)
         if: ${{ inputs.dockerImageMode == 'branch_ref' }}
         run: |
-          export IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
-          echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+          echo "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
 
       - name: Validate image version
         if: ${{ env.IMAGE_VERSION == '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,10 +115,12 @@ jobs:
 
       - name: Generate build args
         run: |
-          BUILD_ARGS="version=${{ env.IMAGE_VERSION }}"
-          if [[ ! -z "${{ inputs.buildArgs }}" ]]; then
-            BUILD_ARGS="${{ inputs.buildArgs }}" 
+          BUILD_ARGS=$(echo ${inputs.buildArgs} | sed 's/^ *//g')
+          if [[ ${BUILD_ARGS::1} != "|" ]]; then
+            BUILD_ARGS="|\n${BUILD_ARGS}"
           fi
+          BUILD_ARGS+="\n"
+          BUILD_ARGS+="version=${{ env.IMAGE_VERSION }}"
           echo "BUILD_ARGS=${BUILD_ARGS}"
           echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,32 +76,32 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Build docker image version
-        shell: bash
+      - name: Generate image version (CUSTOM)
+        if: ${{ inputs.dockerImageMode == "custom" }}
         run: |
-          echo "[debug] dockerImage: ${{ inputs.dockerImage }}"
-          echo "[debug] dockerImageMode: ${{ inputs.dockerImageMode }}"
-          echo "[debug] chartPath: ${{ inputs.chartPath }}"
-          if [ -z "${{ inputs.dockerImage }}" ]
-          then
-            export IMAGE_VERSION="${{ inputs.dockerImage }}"
-          else if [ "${{ inputs.dockerImageMode }}" = "chart_version" ] && [ ! -z "${{ inputs.chartPath }}" ]
-          then
-            export IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
-          else if [ "${{ inputs.dockerImageMode }}" =  "branch_ref" ]
-          then
-            export IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
-          else
-            echo "Invalid IMAGE_VERSION configuration"
-            exit 1
-          fi
-          echo "[debug] IMAGE_VERSION=${{ IMAGE_VERSION }}"
-          if [ -z "${{ IMAGE_VERSION }}" ]
-          then
-            echo "[error] image version is empty"
-            exit 1
-          fi
+          echo "IMAGE_VERSION=${{ inputs.dockerImage }}" >> $GITHUB_ENV
+
+      - name: Generate image version (CHART_REF)
+        if: ${{ inputs.dockerImageMode == "chart_ref" }}
+        run: |
+          echo "CHART_PATH=${{ inputs.chartPath }}"
+          export IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
           echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
+
+      - name: Generate image version (BRANCH_REF)
+        if: ${{ inputs.dockerImageMode == "branch_ref" }}
+        run: |
+          export IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
+          echo "IMAGE_VERSION=${{ IMAGE_VERSION }}" >> $GITHUB_ENV
+
+      - name: Validate image version
+        if: ${{ env.IMAGE_VERSION == "" }}
+        run: |
+          echo "[debug] inputs.dockerImageMode: ${{ inputs.dockerImageMode }}"
+          echo "[debug] inputs.dockerImage: ${{ inputs.dockerImage }}"
+          echo "[debug] inputs.chartPath: ${{ inputs.chartPath }}"
+          echo "[error] env.IMAGE_VERSION is empty"
+          exit 1
 
       - name: Build and push image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,10 @@ jobs:
       - name: Generate image version (CHART_REF)
         if: ${{ inputs.dockerImageMode == 'chart_ref' }}
         run: |
+          if [[ -z ${{ inputs.chartPath }} ]]; then
+            echo "inputs.chartPath must be set in dockerImageMode 'chart_ref'"
+            exit 1
+          fi
           IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | cut -d ":" -f2 | tr -d ' ')
           echo "CHART_PATH=${{ inputs.chartPath }}"
           echo "IMAGE_VERSION=${IMAGE_VERSION}"

--- a/README.md
+++ b/README.md
@@ -44,15 +44,22 @@ to chart version. This allows dynamically inject built version to your applicati
 
 ### inputs
 
-| input          | default  | description                                         |
-|----------------|----------|-----------------------------------------------------|
-| chartPath      | N/A      | helm Chart.yaml path e.g. charts/yourapp/Chart.yaml |
-| dockerRegistry | quay.io  | name of the docker registry                         |
-| dockerRepo     | oriedge  | name of the docker repository                       |
-| imageName      | N/A      | name of the docker image to be built                |
-| buildContext   | .        | docker build context                                |
+| input           | required | default                 | description                                                              |
+|-----------------|----------|-------------------------|--------------------------------------------------------------------------|
+| buildArgs       | false    |                         | docker build args (See --build-arg in docker docs)                       |
+| buildContext    | false    | .                       | docker build context                                                     |
+| chartPath       | false    |                         | helm Chart.yaml path e.g. charts/yourapp/Chart.yaml                      |
+| dockerFile      | false    |                         | the path to the Dockerfile to generate the image from                    |
+| dockerImageMode | false    | chart_ref               | how the imageVersion should be generated (chart_ref, branch_ref, custom) |
+| dockerRegistry  | false    | quay.io                 | name of the docker registry                                              |
+| dockerRepo      | false    | oriedge                 | name of the docker repository                                            |
+| imageName       | true     |                         | name of the docker image to be built                                     |
+| imageVersion    | false    |                         |                                                                          |  
+| platforms       | false    | linux/amd64,linux/arm64 | the list of platforms/architectures to compile the docker image against  |
+| push            | false    | true                    | flag to indicate if the generated docker image should be pushed or not   | 
 
 ### secrets
+
 | input              | default  | description              |
 |--------------------|----------|--------------------------|
 | REGISTRY_USERNAME  | N/A      | docker registry username |

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ to chart version. This allows dynamically inject built version to your applicati
 ```yaml
 jobs:
   docker:
-    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@main
+    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@v0.3.0
     with:
-      chartPath: "charts/example-app/Chart.yaml"
+      dockerImageMode: branch_ref
       imageName: example-app
+      platforms: linux/amd64
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ to chart version. This allows dynamically inject built version to your applicati
 
 ### inputs
 
-| input           | required | default                 | description                                                              |
-|-----------------|----------|-------------------------|--------------------------------------------------------------------------|
-| buildArgs       | false    |                         | docker build args (See --build-arg in docker docs)                       |
-| buildContext    | false    | .                       | docker build context                                                     |
-| chartPath       | false    |                         | helm Chart.yaml path e.g. charts/yourapp/Chart.yaml                      |
-| dockerFile      | false    |                         | the path to the Dockerfile to generate the image from                    |
-| dockerImageMode | false    | chart_ref               | how the imageVersion should be generated (chart_ref, branch_ref, custom) |
-| dockerRegistry  | false    | quay.io                 | name of the docker registry                                              |
-| dockerRepo      | false    | oriedge                 | name of the docker repository                                            |
-| imageName       | true     |                         | name of the docker image to be built                                     |
-| imageVersion    | false    |                         |                                                                          |  
-| platforms       | false    | linux/amd64,linux/arm64 | the list of platforms/architectures to compile the docker image against  |
-| push            | false    | true                    | flag to indicate if the generated docker image should be pushed or not   | 
+| input           | required | default                 | description                                                                        |
+|-----------------|----------|-------------------------|------------------------------------------------------------------------------------|
+| buildArgs       | false    |                         | docker build args (See --build-arg in docker docs)                                 |
+| buildContext    | false    | .                       | docker build context                                                               |
+| chartPath       | false    |                         | helm Chart.yaml path e.g. charts/yourapp/Chart.yaml                                |
+| dockerFile      | false    |                         | the path to the Dockerfile to generate the image from                              |
+| dockerImageMode | false    | chart_ref               | how the imageVersion should be generated (chart_ref, branch_ref, custom)           |
+| dockerRegistry  | false    | quay.io                 | name of the docker registry                                                        |
+| dockerRepo      | false    | oriedge                 | name of the docker repository                                                      |
+| imageName       | true     |                         | name of the docker image to be built                                               |
+| imageVersion    | false    |                         | over-ride image version ({dockerRegistry}/{dockerRepo}/{imageName}:{imageVersion}) |  
+| platforms       | false    | linux/amd64,linux/arm64 | the list of platforms/architectures to compile the docker image against            |
+| push            | false    | true                    | flag to indicate if the generated docker image should be pushed or not             | 
 
 ### secrets
 


### PR DESCRIPTION
## Overview

Support new `dockerImageMode` feature, or the ability for the image version to come from different sources.

The modes supported by this PR are:

- `custom` (Engineer picks a fixed name using `imageVersion` a static value as an argument)
- `branch_ref` (This workflow will generate version using a git branch ref)
- `chart_ref` (This workflow will generate version using the given helm `chartPath` input/version) [Current logic]

The default mode is `chart_ref` for backwards compatibility to existing configs referencing this action.

If the defined `dockerImageMode` is `chart_ref` or `branch_ref`, but `imageVersion` is defined; then `imageVersion` takes priority.

If an unrecognized mode is given the pipeline will fail a validation step pre-build & push.

## Extras

- Supports control on `platforms` so we can build one or both of `amd64` or `arm64` (Default is `linux/amd64,linux/arm64` or both)
- Supports control on `push` so we can just build the image but not push it (Default is `true`)
- Supports control of `build-args` so we can also use this for deploy `consumer` and `producer` which are currently args passed manually to docker build action
- Stops before build and push if `chartPath` is missing and mode `chart_ref` is defined with a helpful error message
- Stops before build and push if the generated image version is still empty (For example if given a blank version name)

## Example configs (chart_ref)

- https://github.com/ori-edge/ori-ms-template/pull/38

```
  docker:
    needs: git-tag
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      chartPath: "charts/ori-ms-template/Chart.yaml"
      imageName: ori-ms-template
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```
```
  build-and-push:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: chart_ref
      chartPath: "charts/ori-ms-template/Chart.yaml"
      imageName: ori-ms-template
      push: false
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```

Note: `dockerImageMode` is optional and defaults to `chart_ref` for backwards compatability.

## Example config (branch_ref)

- https://github.com/ori-edge/ori-ms-template/pull/37
- https://github.com/ori-edge/oge-deploy/pull/93

```
  build-and-push:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: branch_ref
      imageName: oge-deploy-consumer
      buildArgs: target=consumer
      platforms: linux/amd64
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```
```
  build-and-push:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: branch_ref
      imageName: oge-deploy-consumer
      buildArgs: |
        target=consumer
        version=version
      platforms: linux/amd64
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```

## Example config (custom)

- https://github.com/ori-edge/ori-ms-template/pull/39

```
  build-and-push:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: custom
      imageName: ori-ms-template
      imageVersion: custom
      platforms: linux/amd64
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```

## Example config (file)

- https://github.com/ori-edge/oge-bootstrap-agent/pull/53

```
  build-and-push-bootstrap-agent:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: branch_ref
      dockerFile: Dockerfile
      imageName: oge-bootstrap-agent
      platforms: linux/amd64
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```
```
  build-and-push-vpn-agent:
    needs: [ lint, unit-test, integration ]
    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@feature/new-docker-params-and-ci
    with:
      dockerImageMode: branch_ref
      dockerFile: Dockerfile-vpn
      imageName: oge-vpn-agent
      platforms: linux/amd64
    secrets:
      REGISTRY_USERNAME: ${{ secrets.QUAY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
```