### PR TITLE
[Fix] Disable registry login if push disabled

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to quay.io Container Registry
+        if: ${{ inputs.push }}
         uses: docker/login-action@v2
         with:
           registry: ${{ inputs.dockerRegistry }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to quay.io Container Registry
+      - name: Login to docker registry
         if: ${{ inputs.push }}
         uses: docker/login-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ to chart version. This allows dynamically inject built version to your applicati
 ```yaml
 jobs:
   docker:
-    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@v0.3.0
+    uses: ori-edge/oge-github-actions/.github/workflows/docker.yml@v0.5.0
     with:
       dockerImageMode: branch_ref
       imageName: example-app


### PR DESCRIPTION
## Overview

- When push is disabled we should avoid logging into registry it's an unnecessary step
- It's particularly painful as dependabot does not easily have access to secrets
- So this login step fails as the passed secrets on dependabot PRs are empty
- I am passing `push: false` for dependabot PRs, but this step still fails as registry login fails
- My aim is we can use this workflow to just docker build without being forced to pass valid registry login credentials