### PR TITLE
[Integration] Add new github action to manage integration tests

### DIFF
--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -45,27 +45,26 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip check
-        if: ${{ inputs.skip }}
-        run: bash -c "return 0"
       - name: Check out
+        if: ${{ ! inputs.skip }}
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Go
+        if: ${{ ! inputs.skip }}
         uses: actions/setup-go@v3
         with:
           go-version:  ${{ inputs.goVersion }}
       - name: Login to docker registry
-        if: ${{ inputs.loginToDockerRegistry }}
+        if: ${{ ! inputs.skip && inputs.loginToDockerRegistry }}
         uses: docker/login-action@v2
         with:
           registry: ${{ inputs.dockerRegistry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Setup tests
-        if: ${{ inputs.setupCommand }}
+        if: ${{ ! inputs.skip && inputs.setupCommand }}
         run: bash -c "${{ inputs.setupCommand }}"
       - name: Run tests
-        if: ${{ inputs.testCommand }}
+        if: ${{ ! inputs.skip && inputs.testCommand }}
         run: bash -c "${{ inputs.testCommand }}"

--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -1,0 +1,71 @@
+name: Go integration test
+
+on:
+  workflow_call:
+    inputs:
+      skip:
+        description: "flag to indicate if this workflow should skip"
+        default: false
+        required: false
+        type: boolean
+      goVersion:
+        description: "version of go to use"
+        default: "1.18.4"
+        required: false
+        type: string
+      loginToDockerRegistry:
+        description: "flag to indicate if docker registry login is required"
+        default: false
+        required: false
+        type: boolean
+      dockerRegistry:
+        description: "docker registry hostname"
+        required: false
+        default: "quay.io"
+        type: string
+      setupCommand:
+        description: "setup test command to run using bash"
+        default: "make up"
+        required: false
+        type: string
+      testCommand:
+        description: "integration test command to run using bash"
+        default: "make integration"
+        required: false
+        type: string
+    secrets:
+      REGISTRY_USERNAME:
+        description: "docker registry username"
+        required: false
+      REGISTRY_PASSWORD:
+        description: "docker registry password"
+        required: false
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip check
+        if: ${{ inputs.skip }}
+        run: bash -c "return 0"
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version:  ${{ inputs.goVersion }}
+      - name: Login to docker registry
+        if: ${{ inputs.loginToDockerRegistry }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.dockerRegistry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Setup tests
+        if: ${{ inputs.setupCommand }}
+        run: bash -c "${{ inputs.setupCommand }}"
+      - name: Run tests
+        if: ${{ inputs.testCommand }}
+        run: bash -c "${{ inputs.testCommand }}"

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ jobs:
 ```
 
 ## go-integration-test
-GitHub workflow to run go test and upload the coverage report to codecov (optional)
+GitHub workflow to run go integration tests (supports docker registry login if private images required).
 
 ### inputs
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ jobs:
       dockerImageMode: branch_ref
       imageName: example-app
       platforms: linux/amd64
+      push: ${{ github.actor != 'dependabot[bot]' }}
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -166,6 +167,36 @@ GitHub workflow to run go test and upload the coverage report to codecov (option
 jobs:
   unit-test:
     uses: ori-edge/oge-github-actions/.github/workflows/go-unit-test.yml@v0.4.0
+    with:
+      uploadToCodecov: ${{ github.actor != 'dependabot[bot]' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+```
+
+## go-integration-test
+GitHub workflow to run go test and upload the coverage report to codecov (optional)
+
+### inputs
+
+| input                 | required | default          | description                                           |
+|-----------------------|----------|------------------|-------------------------------------------------------|
+| skip                  | false    | false            | flag to indicate if this workflow should skip         |
+| goVersion             | false    | 1.18.4           | version of go to load                                 |
+| loginToDockerRegistry | false    | false            | flag to indicate if docker registry login is required |
+| dockerRegistry        | false    | quay.io          | docker registry hostname                              |
+| setupCommand          | false    | make up          | setup test command to run using bash                  |
+| testCommand           | false    | make integration | integration test command to run using bash            |
+
+### workflow example
+
+```yaml
+jobs:
+  integration:
+    uses: ori-edge/oge-github-actions/.github/workflows/go-integration-test.yml@v0.6.0
+    with:
+      skip: ${{ github.actor == 'dependabot[bot]' }}
+      loginToDockerRegistry: true
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 ```


### PR DESCRIPTION
## Description

- We currently verbosely define a workflow job in all our CI pipelines for integration testing with `kind` cluster
- It would be helpful to abstract this to a github action that we could conditionally skip in dependabot context
- Dependabot does not ahve access to CI secrets anymore on GitHub and GH dont recommend enabling them there
- The best way to curb this that I've found, is to skip integration test that requires secrets in that context
- If we use a `skip` at job level any dependant jobs don't run, blame github conditional logic
- To get around this I put a conditional in the integration job steps that will early terminate the job if a `skip` param is passed
- This enables the job to run but not do anything, so downstream dependant jobs still run

## Example usages of new workflow

```
jobs:
  integration:
    uses: ori-edge/oge-github-actions/.github/workflows/go-integration-test.yml@v0.6.0
```

```
jobs:
  integration:
    uses: ori-edge/oge-github-actions/.github/workflows/go-integration-test.yml@v0.6.0
    with:
      skip: ${{ github.actor == 'dependabot[bot]' }}
      goVersion: 1.18.4
      loginToDockerRegistry: true
      dockerRegistry: quay.io
      setupCommand: "make up"
      testCommand: "make integration"
    secrets:
      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
```

## Ref

- https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/