### PR TITLE
Fix gcp-helm-charts upload action as broken

### DIFF
--- a/.github/workflows/gcp-helm-charts.yml
+++ b/.github/workflows/gcp-helm-charts.yml
@@ -34,7 +34,7 @@ jobs:
         run: helm package ./charts/* --destination ./charts
 
       - name: Push chart to GCP Cloud Storage
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0.10.4
         with:
           credentials: ${{ secrets.GCP_CREDENTIALS }}
           path: ./charts

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ GitHub workflow to build helm charts and push to gcp. All helm charts are expect
 ```yaml
 jobs:
   gcp-helm-charts:
-    uses: ori-edge/oge-github-actions/.github/workflows/gcp-helm-charts.yml@v0.3.0
+    uses: ori-edge/oge-github-actions/.github/workflows/gcp-helm-charts.yml@v0.7.2
     with:
       chartPath: "charts/example-app/Chart.yaml"
       gcpDestination: "helm-charts"


### PR DESCRIPTION
Google have removed support for the `credential` field in their recent changes:

- https://github.com/google-github-actions/upload-cloud-storage/blob/v0.10.4/src/main.ts#L73-L80
- https://github.com/google-github-actions/upload-cloud-storage/blob/main/src/main.ts#L73-L80

We need to pin to an older version to return stability, until we can circle back and bump the workflow for the new auth style.

ref:
- https://github.com/google-github-actions/upload-cloud-storage/issues/212