### PR TITLE
added option to set charts path in gcp-helm-charts

### DIFF
--- a/.github/workflows/gcp-helm-charts.yml
+++ b/.github/workflows/gcp-helm-charts.yml
@@ -3,6 +3,11 @@ name: Build helm charts and push to gcp
 on:
   workflow_call:
     inputs:
+      chartsPath:
+        description: "path chart files (including glob pattern)"
+        required: false
+        default: "./charts/*"
+        type: string
       gcpDestination:
         description: "gcp directory where the packaged chart will be uploaded"
         required: true
@@ -25,7 +30,7 @@ jobs:
         uses: Azure/setup-helm@v4.2.0
 
       - name: Package Helm Chart
-        run: helm package ./charts/* --destination ./charts
+        run: helm package ${{ inputs.chartsPath }} --destination ./charts
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.3


### PR DESCRIPTION
The new frontend monorepo will have multiple `charts` folders set up (one for each app). We need to be able to specify the app specific path in the build script via an option to the workflow.

This update adds a new optional `chartsPath` variable that can be added to the `release.yml` script to specify the correct path for each app individually. The currently hard-coded charts path is set as default value so existing scripts can be updated without adjustment.