### PR TITLE
Adopt sha pinning for github actions

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -27,7 +27,7 @@ jobs:
         run: docker build -t ${{ github.repository }}:${{ github.sha }} ${{ inputs.buildContext }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.17.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: "${{ github.repository }}:${{ github.sha }}"
           format: "table"


### PR DESCRIPTION
Adopt sha pinning for GHA in the wake of recently software supply chain attacks[1]

[1] https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release