### PR TITLE
OGE-11946: updated GitHub actions to latest versions

### DIFF
--- a/.github/workflows/auto-semver-ci.yml
+++ b/.github/workflows/auto-semver-ci.yml
@@ -19,11 +19,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: auto-semver/package-lock.json
 
@@ -40,7 +40,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Use a token that can push to a protected main branch if needed.
           # For unprotected branches the default GITHUB_TOKEN is sufficient.
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: auto-semver/package-lock.json
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # need local checkout to use action from current branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test compute next version
         id: semver
         uses: ./auto-semver

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,19 +74,19 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to docker registry
         if: ${{ inputs.push }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.dockerRegistry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -131,7 +131,7 @@ jobs:
           echo "BUILD_ARGS=${BUILD_ARGS}" >> $GITHUB_ENV
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.buildContext }}
           file: ${{ inputs.dockerFile }}

--- a/.github/workflows/gcp-helm-charts.yml
+++ b/.github/workflows/gcp-helm-charts.yml
@@ -27,23 +27,23 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Helm tool installer
-        uses: Azure/setup-helm@v4.2.0
+        uses: Azure/setup-helm@v5
 
       - name: Package Helm Chart
         run: helm package ${{ inputs.chartsPath }} --destination ./charts
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.3
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Push chart to GCP Cloud Storage
-        uses: google-github-actions/upload-cloud-storage@v2.1.0
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ./charts
           glob: "*.tgz"

--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Check out
         if: ${{ ! inputs.skip }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Download build artifact
@@ -95,10 +95,10 @@ jobs:
           git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/ori-edge/".insteadOf "https://github.com/ori-edge/"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to docker registry
         if: ${{ ! inputs.skip && inputs.loginToDockerRegistry }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.dockerRegistry }}
           username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Go
@@ -75,7 +75,7 @@ jobs:
 
       - name: Login to docker registry
         if: ${{ inputs.loginDocker }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.dockerRegistry }}
           username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -45,9 +45,9 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: ${{ inputs.helmVersion }}
       - name: Helm lint

--- a/.github/workflows/tag-helm-release-ci.yml
+++ b/.github/workflows/tag-helm-release-ci.yml
@@ -19,11 +19,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: tag-helm-release/package-lock.json
 
@@ -40,13 +40,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: tag-helm-release/package-lock.json
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wait-for-deploy.yml
+++ b/.github/workflows/wait-for-deploy.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ inputs.runsOn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/auto-semver/README.md
+++ b/auto-semver/README.md
@@ -15,16 +15,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # required to push tags
+      contents: write # required to push tags
 
     steps:
       - name: Compute next version
         id: semver
         uses: ori-edge/oge-github-actions/auto-semver@v1
         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           
-      - uses: actions/checkout@v4
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v6
         if: steps.semver.outputs.tag != ''
 
       - name: Tag and push
@@ -56,9 +56,9 @@ jobs:
         id: semver
         uses: ori-edge/oge-github-actions/auto-semver@v1
         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           
-      - uses: actions/checkout@v4
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v6
         if: steps.semver.outputs.tag != ''
 
       - name: Create tagging commit and push
@@ -78,30 +78,30 @@ continues from the same point, and any in-flight PRs merge without conflict.
 
 ## Inputs
 
-| Input | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `tag-parent-depth` | No | `1` | Number of first-parent hops to walk back from the tag's commit to find the ancestor on the main branch. See [Tagging topology](#tagging-topology). |
+| Input              | Required | Default | Description                                                                                                                                        |
+| ------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tag-parent-depth` | No       | `1`     | Number of first-parent hops to walk back from the tag's commit to find the ancestor on the main branch. See [Tagging topology](#tagging-topology). |
 
 ## Outputs
 
 All outputs are empty strings when there is nothing to release.
 
-| Output | Description |
-|--------|-------------|
-| `version` | Next version string, e.g. `1.2.3` |
-| `tag` | Next tag, e.g. `v1.2.3` |
-| `bump` | Bump type applied: `major`, `minor`, or `patch` |
+| Output    | Description                                     |
+| --------- | ----------------------------------------------- |
+| `version` | Next version string, e.g. `1.2.3`               |
+| `tag`     | Next tag, e.g. `v1.2.3`                         |
+| `bump`    | Bump type applied: `major`, `minor`, or `patch` |
 
 ## Bump rules
 
 The highest bump across all commits since the last tag wins.
 
-| Commit | Bump |
-|--------|------|
-| Subject matches `type!:` or `type(scope)!:` | `major` |
+| Commit                                                                   | Bump    |
+| ------------------------------------------------------------------------ | ------- |
+| Subject matches `type!:` or `type(scope)!:`                              | `major` |
 | Any line in the message matches `BREAKING CHANGE:` or `BREAKING-CHANGE:` | `major` |
-| Subject matches `feat:` or `feat(scope):` | `minor` |
-| Anything else (including non-conventional commits) | `patch` |
+| Subject matches `feat:` or `feat(scope):`                                | `minor` |
+| Anything else (including non-conventional commits)                       | `patch` |
 
 Full commit messages are scanned — not just the subject line — so
 `BREAKING CHANGE` footers in squash-merge bodies are correctly detected.


### PR DESCRIPTION
GitHub has [deprecated Node v20 for action ](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and will disabled it from June 2026. We are using a number of outdated actions that depend on Node v20 and they are generating warning messages. 

For most of these there are updated versions available that set the default Node version to v24. In this PR I have updated all actions I could identify to the latests version. They should now all run on Node24. I have not seen any mention of breaking changes in the change logs but I have not way to verify this.

I also updated the Node versions for our own actions from v20 to v24. We may consider to bump the version because of this.

This does not include **dependabot**.  I do not know how the runtime for dependabot is configured. So this action still generates warning messages.