### PR TITLE
feat: add support for mise.toml to go shared workflows [OGE-12017]

### DIFF
--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -73,6 +73,7 @@ jobs:
       MISE_TOML_TEMPLATE: |-
         [tools]
         go =
+      MISE_GO_SET_GOBIN: 'false'
     steps:
       - name: Check out
         if: ${{ ! inputs.skip }}

--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: boolean
       goVersion:
-        description: "version of go to use"
+        description: "version of go to use (deprecated: use mise.toml instead)"
         default: "stable"
         required: false
         type: string
@@ -69,6 +69,10 @@ on:
 jobs:
   integration-test:
     runs-on: ${{ inputs.runsOn }}
+    env:
+      MISE_TOML_TEMPLATE: |-
+        [tools]
+        go =
     steps:
       - name: Check out
         if: ${{ ! inputs.skip }}
@@ -81,12 +85,18 @@ jobs:
         with:
           name: ${{ inputs.buildArtifactName }}
           path: ${{ inputs.buildArtifactName }}/
+      - name: Setup mise
+        if: ${{ ! inputs.skip }}
+        uses: jdx/mise-action@v2
+        with:
+          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, inputs.goVersion), '') }}
       - name: Setup Go
         if: ${{ ! inputs.skip }}
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.goVersion }}
-          cache-dependency-path: go.sum
+          cache-dependency-path: |
+            go.sum
+            mise.toml
       - name: Configure GitHub authentication
         env:
           HAS_TOKEN: ${{ secrets.GH_TOKEN != '' }}

--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ ! inputs.skip }}
         uses: jdx/mise-action@v2
         with:
-          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, inputs.goVersion), '') }}
+          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, case(inputs.goVersion == 'stable', 'latest', inputs.goVersion)), '') }}
       - name: Setup Go
         if: ${{ ! inputs.skip }}
         uses: actions/setup-go@v5

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -59,6 +59,7 @@ jobs:
       MISE_TOML_TEMPLATE: |-
         [tools]
         go =
+      MISE_GO_SET_GOBIN: 'false'
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -74,7 +75,6 @@ jobs:
           cache-dependency-path: |
             go.sum
             mise.toml
-
       - name: Configure GitHub authentication
         env:
           HAS_TOKEN: ${{ secrets.GH_TOKEN != '' }}

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       goVersion:
-        description: "version of go to use"
+        description: "version of go to use (deprecated: use mise.toml instead)"
         default: "stable"
         required: false
         type: string
@@ -55,16 +55,25 @@ on:
 jobs:
   unit-test:
     runs-on: ${{ inputs.runsOn }}
+    env:
+      MISE_TOML_TEMPLATE: |-
+        [tools]
+        go =
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, inputs.goVersion), '') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.goVersion }}
-          cache-dependency-path: go.sum
+          cache-dependency-path: |
+            go.sum
+            mise.toml
 
       - name: Configure GitHub authentication
         env:

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
         with:
-          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, inputs.goVersion), '') }}
+          mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, case(inputs.goVersion == 'stable', 'latest', inputs.goVersion)), '') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       goVersionFile:
-        description: "path to file containing Go version (e.g., .go-version or go.mod)"
+        description: "path to file containing Go version (e.g., .go-version or go.mod); ignored when mise.toml is present (deprecated: use mise.toml instead)"
         default: "go.mod"
         required: false
         type: string
@@ -29,10 +29,20 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+      - name: Create mise.toml from goVersionFile
+        if: ${{ hashFiles('mise.toml') == '' }}
+        run: |
+          ver=$(grep -m1 '^go ' "${{ inputs.goVersionFile }}" | awk '{print $2}' \
+                || cat "${{ inputs.goVersionFile }}")
+          printf '[tools]\ngo = "%s"\n' "$ver" > mise.toml
+      - name: Setup mise
+        uses: jdx/mise-action@v2
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: ${{ inputs.goVersionFile }}
+          cache-dependency-path: |
+            go.sum
+            mise.toml
 
       - name: Configure GitHub authentication
         env:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -26,6 +26,8 @@ on:
 jobs:
   govulncheck:
     runs-on: ${{ inputs.runsOn }}
+    env:
+      MISE_GO_SET_GOBIN: 'false'
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -50,6 +52,9 @@ jobs:
         if: env.HAS_TOKEN == 'true'
         run: |
           git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/ori-edge/".insteadOf "https://github.com/ori-edge/"
+
+      - name: Add GOBIN to PATH
+        run: echo "$(go env GOBIN)" >> $GITHUB_PATH
 
       - name: Run govulncheck
         run: |


### PR DESCRIPTION
Tested against ope-supercomputer-manager and oge-supercomputer-operator and works with or without a `mise.toml` file present in the repo which allows upgrade to new version of shared workflows before switching to mise