### PR TITLE
chore: fix input name for codecov upload

### DIFF
--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -131,6 +131,6 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ inputs.coverageFilePath }}
+          files: ${{ inputs.coverageFilePath }}
           flags: integration
           name: codecov-umbrella

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -97,6 +97,6 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ inputs.coverageFilePath }}
+          files: ${{ inputs.coverageFilePath }}
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
Should resolve this warning:
<img width="1295" height="243" alt="Screenshot 2026-05-13 at 14 52 43" src="https://github.com/user-attachments/assets/ea971305-55e5-494b-80d9-92d4408e9767" />
