### PR TITLE
enable mise idiomatic Go version resolution from go.mod

### DIFF
--- a/.github/workflows/go-integration-test.yml
+++ b/.github/workflows/go-integration-test.yml
@@ -89,6 +89,11 @@ jobs:
       - name: Setup mise
         if: ${{ ! inputs.skip }}
         uses: jdx/mise-action@v4
+        env:
+          # let consumers omit `go` from mise.toml's [tools] and source the
+          # version from go.mod via mise's idiomatic-file resolver; explicit
+          # [tools] pins still win, so this is backwards-compatible
+          MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS: go
         with:
           mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, case(inputs.goVersion == 'stable', 'latest', inputs.goVersion)), '') }}
       - name: Setup Go

--- a/.github/workflows/go-unit-test.yml
+++ b/.github/workflows/go-unit-test.yml
@@ -67,6 +67,11 @@ jobs:
           fetch-depth: 0
       - name: Setup mise
         uses: jdx/mise-action@v4
+        env:
+          # let consumers omit `go` from mise.toml's [tools] and source the
+          # version from go.mod via mise's idiomatic-file resolver; explicit
+          # [tools] pins still win, so this is backwards-compatible
+          MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS: go
         with:
           mise_toml: ${{ case(hashFiles('mise.toml') == '', format('{0} "{1}"', env.MISE_TOML_TEMPLATE, case(inputs.goVersion == 'stable', 'latest', inputs.goVersion)), '') }}
       - name: Setup Go

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -39,6 +39,11 @@ jobs:
           printf '[tools]\ngo = "%s"\n' "$ver" > mise.toml
       - name: Setup mise
         uses: jdx/mise-action@v4
+        env:
+          # let consumers omit `go` from mise.toml's [tools] and source the
+          # version from go.mod via mise's idiomatic-file resolver; explicit
+          # [tools] pins still win, so this is backwards-compatible
+          MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS: go
       - name: Setup Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
in `ogc-kubernetes-manager` i don't want to maintain separate Go version both in go.mod and mise.toml. this change let's mise pick up go version from go.mod - while keeping it backwards compatible, because `[tools]` specific Go version gets interpreted first