### PR TITLE
fix: docker build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,25 +70,106 @@ release:
 
 ---
 
+### resolve-release-version
+
+Determines the version to release on every push to main. Supports two modes
+selected via the `mode` input:
+
+- **`manual`** (old system): reads the version from `Chart.yaml`. If that version has
+  not yet been tagged, uses it as the release. If it is already tagged (no bump was
+  made), outputs empty — nothing to release. There is no auto-semver fallback; the
+  caller controls releases entirely by bumping the chart.
+- **`auto`** (default, new system): runs `auto-semver` to compute the next clean
+  release version from conventional commits since the last tag. Use this for repos
+  that keep a placeholder (e.g. `0.0.0-dev`) in `Chart.yaml`.
+
+Requires a checkout with `fetch-depth: 0` in the calling job.
+
+#### inputs
+
+| input     | required | default  | description                                                            |
+|-----------|----------|----------|------------------------------------------------------------------------|
+| mode      | false    | `manual` | `'manual'` or `'auto'` — see above                                    |
+| chartPath | false    |          | path to `Chart.yaml`; required when `mode` is `'manual'`              |
+
+#### env vars (pass as env: on the step)
+
+| var          | description                                      |
+|--------------|--------------------------------------------------|
+| GITHUB_TOKEN | GitHub token (read-only scope is enough for auto; not needed for manual) |
+
+#### outputs
+
+| output  | description                                                          |
+|---------|----------------------------------------------------------------------|
+| version | version to release, e.g. `1.2.3`. Empty if nothing to release.      |
+| tag     | tag to create, e.g. `v1.2.3`. Empty if nothing to release.          |
+
+#### example — manual mode (Chart.yaml controls the version)
+
+```yaml
+- uses: actions/checkout@v6
+  with: { fetch-depth: 0 }
+
+- id: version
+  uses: ori-edge/oge-github-actions/resolve-release-version@v0.25.0
+  with:
+    mode: manual
+    chartPath: charts/my-service/Chart.yaml
+
+- if: steps.version.outputs.tag != ''
+  uses: ori-edge/oge-github-actions/tag@v0.25.0
+  with:
+    tags: ${{ steps.version.outputs.tag }}
+  env:
+    GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+```
+
+#### example — auto mode (conventional commits control the version)
+
+```yaml
+- uses: actions/checkout@v6
+  with: { fetch-depth: 0 }
+
+- id: version
+  uses: ori-edge/oge-github-actions/resolve-release-version@v0.25.0
+  env:
+    GITHUB_TOKEN: ${{ github.token }}
+
+- if: steps.version.outputs.tag != ''
+  uses: ori-edge/oge-github-actions/tag@v0.25.0
+  with:
+    tags: ${{ steps.version.outputs.tag }}
+  env:
+    GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+```
+
+---
+
 ### docker-build
 
 Checks out the caller's repo, computes the image version, and builds/pushes a Docker image.
 Version is resolved via `compute-version`: if `imageVersion` is provided it is used directly; otherwise
 discovered from git tags.
 
+The image is always pushed with two tags: the resolved version and the current branch name
+(e.g. `main`). This ensures dev environments that track the `main` tag are updated on every merge.
+
 #### inputs
 
-| input          | required | default                 | description                                                                  |
-|----------------|----------|-------------------------|------------------------------------------------------------------------------|
-| buildArgs      | false    |                         | docker build args (see --build-arg in docker docs)                           |
-| buildContext   | false    | .                       | docker build context                                                         |
-| dockerFile     | false    |                         | path to the Dockerfile                                                       |
-| dockerRegistry | false    | quay.io                 | name of the docker registry                                                  |
-| dockerRepo     | false    | oriedge                 | name of the docker repository                                                |
-| imageName      | true     |                         | name of the docker image to be built                                         |
-| imageVersion   | false    |                         | explicit image version; if empty, computed from git tags via compute-version |
-| platforms      | false    | linux/amd64,linux/arm64 | comma-separated list of platforms to build for                               |
-| push           | false    | true                    | `'true'` to push the image to the registry                                   |
+| input           | required | default                 | description                                                                                          |
+|-----------------|----------|-------------------------|------------------------------------------------------------------------------------------------------|
+| buildArgs       | false    |                         | docker build args (see --build-arg in docker docs)                                                   |
+| buildContext    | false    | .                       | docker build context                                                                                 |
+| chartPath       | false    |                         | path to `Chart.yaml`; required when `dockerImageMode` is `chart_ref`                                |
+| dockerFile      | false    |                         | path to the Dockerfile                                                                               |
+| dockerImageMode | false    |                         | `chart_ref` — read version from `Chart.yaml`; `branch_ref` — use branch name; empty — git tags     |
+| dockerRegistry  | false    | quay.io                 | name of the docker registry                                                                          |
+| dockerRepo      | false    | oriedge                 | name of the docker repository                                                                        |
+| imageName       | true     |                         | name of the docker image to be built                                                                 |
+| imageVersion    | false    |                         | explicit image version; takes precedence over all other version resolution                           |
+| platforms       | false    | linux/amd64,linux/arm64 | comma-separated list of platforms to build for                                                       |
+| push            | false    | true                    | `'true'` to push the image to the registry                                                           |
 
 #### env vars (pass as env: on the step)
 
@@ -149,11 +230,12 @@ otherwise discovered from git tags.
 
 #### inputs
 
-| input          | required | default    | description                                              |
-|----------------|----------|------------|----------------------------------------------------------|
-| chartsPath     | false    | ./charts/* | path to chart files (including glob pattern)             |
-| chartVersion   | false    |            | explicit chart version; if empty, computed from git tags |
-| gcpDestination | true     |            | GCP directory where the packaged chart will be uploaded  |
+| input          | required | default    | description                                                                                       |
+|----------------|----------|------------|---------------------------------------------------------------------------------------------------|
+| chartsPath     | false    | ./charts/* | path to chart files (including glob pattern)                                                      |
+| chartMode      | false    |            | `chart_ref` — read version from each chart's own `Chart.yaml`; empty — use `chartVersion` or git tags |
+| chartVersion   | false    |            | explicit chart version; if empty and `chartMode` is empty, computed from git tags                 |
+| gcpDestination | true     |            | GCP directory where the packaged chart will be uploaded                                           |
 
 #### env vars (pass as env: on the step)
 

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -117,6 +117,25 @@ runs:
           exit 1
         fi
 
+    - name: Compute image tags
+      shell: bash
+      run: |
+        BASE="${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}"
+        TAGS="${BASE}:${{ env.IMAGE_VERSION }}"
+        BRANCH="${GITHUB_HEAD_REF:-}"
+        if [[ -z "$BRANCH" ]] && [[ "$GITHUB_REF" == refs/heads/* ]]; then
+          BRANCH="${GITHUB_REF#refs/heads/}"
+        fi
+        if [[ -n "$BRANCH" ]]; then
+          BRANCH_TAG=$(echo "$BRANCH" | sed 's/\//_/g')
+          if [[ "$BRANCH_TAG" != "${{ env.IMAGE_VERSION }}" ]]; then
+            TAGS="${TAGS}"$'\n'"${BASE}:${BRANCH_TAG}"
+          fi
+        fi
+        echo "DOCKER_TAGS<<EOF" >> $GITHUB_ENV
+        echo "$TAGS" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
     - name: Generate build args
       shell: bash
       run: |
@@ -131,4 +150,4 @@ runs:
         build-args: ${{ env.BUILD_ARGS }}
         platforms: ${{ inputs.platforms }}
         push: ${{ inputs.push }}
-        tags: ${{ inputs.dockerRegistry }}/${{ inputs.dockerRepo }}/${{ inputs.imageName }}:${{ env.IMAGE_VERSION }}
+        tags: ${{ env.DOCKER_TAGS }}

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -71,9 +71,20 @@ runs:
 
     - name: Resolve image version
       id: cv
+      if: inputs.imageVersion == ''
       uses: ./../../_actions/current/compute-version
       with:
         version: ${{ inputs.imageVersion }}
+
+    - name: Set IMAGE_VERSION (explicit)
+      if: inputs.imageVersion != ''
+      shell: bash
+      run: echo "IMAGE_VERSION=${{ inputs.imageVersion }}" >> $GITHUB_ENV
+
+    - name: Set IMAGE_VERSION (computed)
+      if: inputs.imageVersion == ''
+      shell: bash
+      run: echo "IMAGE_VERSION=${{ steps.cv.outputs.version }}" >> $GITHUB_ENV
 
     - name: Set IMAGE_VERSION
       shell: bash

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -1,8 +1,9 @@
 name: "Docker build and push"
 description: >
-  Checks out the caller's repo, computes the image version from git tags (or uses the
-  explicit imageVersion input), then builds and optionally pushes a multi-arch Docker image.
-  Pass REGISTRY_USERNAME and REGISTRY_PASSWORD as env vars on the step when push is true.
+  Checks out the caller's repo, computes the image version from git tags, Chart.yaml,
+  or branch name (or uses the explicit imageVersion input), then builds and optionally
+  pushes a multi-arch Docker image. Pass REGISTRY_USERNAME and REGISTRY_PASSWORD as
+  env vars on the step when push is true.
 inputs:
   buildArgs:
     description: "docker build args (see --build-arg in docker docs)"
@@ -12,8 +13,16 @@ inputs:
     description: "docker build context (relative to repo root)"
     default: "."
     required: false
+  chartPath:
+    description: "helm Chart.yaml path (used by dockerImageMode 'chart_ref')"
+    required: false
+    default: ""
   dockerFile:
     description: "path to the Dockerfile (relative to repo root)"
+    required: false
+    default: ""
+  dockerImageMode:
+    description: "mode to compute image version (chart_ref, branch_ref, or empty for git tags)"
     required: false
     default: ""
   dockerRegistry:
@@ -28,7 +37,7 @@ inputs:
     description: "name of the docker image ({repo}/{name}:{version})"
     required: true
   imageVersion:
-    description: "explicit image version; if empty, computed from git tags"
+    description: "explicit image version; if empty, computed from mode or git tags"
     required: false
     default: ""
   platforms:
@@ -47,10 +56,6 @@ runs:
       with:
         fetch-depth: 0
 
-    # HACK: symlink this repo's root into _actions/current so sibling actions are
-    # reachable as ./../../_actions/current/<name> local paths.
-    # TODO: once https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
-    # ships the $/ syntax, remove this step and replace the local-path uses: below with $/compute-version.
     - name: Link sibling actions
       shell: bash
       run: ln -sf "$GITHUB_ACTION_PATH/.." /home/runner/work/_actions/current
@@ -69,26 +74,48 @@ runs:
         username: ${{ env.REGISTRY_USERNAME }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
-    - name: Resolve image version
+    - name: Generate image version (CHART_REF)
+      if: inputs.dockerImageMode == 'chart_ref'
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.chartPath }}" ]]; then
+          echo "ERROR: inputs.chartPath must be set when dockerImageMode is 'chart_ref'"
+          exit 1
+        fi
+        IMAGE_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | awk '{print $2}')
+        echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
+
+    - name: Generate image version (BRANCH_REF)
+      if: inputs.dockerImageMode == 'branch_ref'
+      shell: bash
+      run: |
+        IMAGE_VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
+        echo "IMAGE_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV
+
+    - name: Resolve image version (GIT_TAG)
+      if: inputs.dockerImageMode == '' && inputs.imageVersion == ''
       id: cv
-      if: inputs.imageVersion == ''
       uses: ./../../_actions/current/compute-version
       with:
         version: ${{ inputs.imageVersion }}
 
-    - name: Set IMAGE_VERSION (explicit)
+    - name: Set IMAGE_VERSION (CUSTOM)
       if: inputs.imageVersion != ''
       shell: bash
       run: echo "IMAGE_VERSION=${{ inputs.imageVersion }}" >> $GITHUB_ENV
 
-    - name: Set IMAGE_VERSION (computed)
-      if: inputs.imageVersion == ''
+    - name: Set IMAGE_VERSION (GIT_TAG)
+      if: inputs.dockerImageMode == '' && inputs.imageVersion == ''
       shell: bash
       run: echo "IMAGE_VERSION=${{ steps.cv.outputs.version }}" >> $GITHUB_ENV
 
-    - name: Set IMAGE_VERSION
+    - name: Validate IMAGE_VERSION
       shell: bash
-      run: echo "IMAGE_VERSION=${{ steps.cv.outputs.version }}" >> $GITHUB_ENV
+      run: |
+        if [[ -z "${{ env.IMAGE_VERSION }}" ]]; then
+          echo "ERROR: IMAGE_VERSION is empty"
+          exit 1
+        fi
 
     - name: Generate build args
       shell: bash

--- a/gcp-helm-charts/action.yml
+++ b/gcp-helm-charts/action.yml
@@ -1,18 +1,24 @@
 name: "Build and push Helm charts to GCP"
 description: >
-  Checks out the caller's repo, computes the chart version from git tags (or uses the
-  explicit chartVersion input), packages all matching Helm charts, and uploads them to
+  Checks out the caller's repo, packages all matching Helm charts, and uploads them to
   a GCP Cloud Storage bucket. Pass GCP_CREDENTIALS as an env var on the step.
+  chartMode controls how the chart version is resolved: empty (default) computes from
+  git tags (or passes through an explicit chartVersion); 'chart_ref' reads the version
+  from each chart's own Chart.yaml (for repos that manually bump their chart version).
 inputs:
   chartsPath:
     description: "glob pattern for chart directories"
     required: false
     default: "./charts/*"
+  chartMode:
+    description: "mode to resolve chart version: empty for git tags, 'chart_ref' to read from Chart.yaml"
+    required: false
+    default: ""
   gcpDestination:
     description: "GCP Cloud Storage destination bucket/path"
     required: true
   chartVersion:
-    description: "explicit chart version; if empty, computed from git tags"
+    description: "explicit chart version; if empty and chartMode is empty, computed from git tags"
     required: false
     default: ""
 runs:
@@ -26,7 +32,8 @@ runs:
       shell: bash
       run: ln -sf "$GITHUB_ACTION_PATH/.." /home/runner/work/_actions/current
 
-    - name: Resolve chart version
+    - name: Resolve chart version (GIT_TAG)
+      if: inputs.chartMode == ''
       id: cv
       uses: ./../../_actions/current/compute-version
       with:
@@ -45,7 +52,11 @@ runs:
       run: |
         for dir in ${{ inputs.chartsPath }}; do
           if [ -d "$dir" ]; then
-            helm package "$dir" --destination ./charts --version "${{ steps.cv.outputs.version }}"
+            if [[ "${{ inputs.chartMode }}" == "chart_ref" ]]; then
+              helm package "$dir" --destination ./charts
+            else
+              helm package "$dir" --destination ./charts --version "${{ steps.cv.outputs.version }}"
+            fi
           fi
         done
 

--- a/resolve-release-version/action.yml
+++ b/resolve-release-version/action.yml
@@ -1,0 +1,78 @@
+name: "resolve-release-version"
+description: >
+  Determines the version to release on push to main. Behaviour depends on the
+  mode input:
+    manual (default): reads Chart.yaml and uses that version if it has not yet been
+      tagged. If the version is already tagged (no bump was made), outputs empty —
+      nothing to release. No auto-semver fallback; the caller controls releases by
+      bumping the chart.
+    auto: runs auto-semver to compute the next clean release version from
+      conventional commits since the last tag. Use this for repos that keep
+      a placeholder (e.g. 0.0.0-dev) in Chart.yaml and rely on CI to version releases.
+  Requires a checkout with fetch-depth: 0 in the calling job.
+  Set GITHUB_TOKEN in the step or job env.
+
+author: "ori-edge"
+
+inputs:
+  mode:
+    description: "'manual' (default) to release only when Chart.yaml version is new; 'auto' to always compute from conventional commits"
+    required: false
+    default: "manual"
+  chartPath:
+    description: "Path to Chart.yaml. Required when mode is 'manual'."
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: "Version to release, e.g. '1.2.3'. Empty if nothing to release."
+    value: ${{ steps.final-manual.outputs.version || steps.final-auto.outputs.version }}
+  tag:
+    description: "Tag to create, e.g. 'v1.2.3'. Empty if nothing to release."
+    value: ${{ steps.final-manual.outputs.tag || steps.final-auto.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Link sibling actions
+      shell: bash
+      run: ln -sf "$GITHUB_ACTION_PATH/.." /home/runner/work/_actions/current
+
+    - name: Resolve version (manual)
+      id: manual
+      if: inputs.mode == 'manual'
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.chartPath }}" ]]; then
+          echo "ERROR: chartPath is required when mode is 'manual'"
+          exit 1
+        fi
+        CHART_VERSION=$(grep '^version:' ${{ inputs.chartPath }} | awk '{print $2}')
+        if ! git tag | grep -qx "v${CHART_VERSION}"; then
+          echo "version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${CHART_VERSION}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Resolve version (auto)
+      id: auto
+      if: inputs.mode == 'auto'
+      uses: ./../../_actions/current/auto-semver
+      with:
+        tag-parent-depth: "0"
+
+    - name: Set final version (manual)
+      id: final-manual
+      if: inputs.mode == 'manual'
+      shell: bash
+      run: |
+        echo "version=${{ steps.manual.outputs.version }}" >> $GITHUB_OUTPUT
+        echo "tag=${{ steps.manual.outputs.tag }}" >> $GITHUB_OUTPUT
+
+    - name: Set final version (auto)
+      id: final-auto
+      if: inputs.mode == 'auto'
+      shell: bash
+      run: |
+        echo "version=${{ steps.auto.outputs.version }}" >> $GITHUB_OUTPUT
+        echo "tag=${{ steps.auto.outputs.tag }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
  fix: support manual and auto versioning systems simultaneously; always push branch tag on docker build

  Previously, dependent repos (e.g. oge-organisations, ogc-vm-provisioner, etc) controlled releases by
  manually bumping the version in Chart.yaml. The recent addition of auto-semver/compute-version
  introduced a second versioning pathway, but in doing so broke repos still using the manual system
  in two ways:

  1. gcp-helm-charts always overrode the chart version with the computed git-tag version, silently
     clobbering whatever was in Chart.yaml when packaging helm charts for upload to GCP.

  2. There was no clean way for a repo's release workflow to choose between "release only when I
     bump Chart.yaml" vs "release automatically based on conventional commits". Both paths were
     entangled in the same action with no explicit mode switch, making it impossible to opt in to
     one without breaking the other.

  Additionally, dependent repos had no way to ensure the `main` tag in Quay was kept up to date on
  every merge. Without a `main` tag, dev environments relying on auto-deploy of the latest image (e.g. standalone database image, used for tests in many of our repos)
  could not receive updates unless a new versioned release was cut.
  Changes:
  
  resolve-release-version (new composite action)
    Single entry point for "what version should I release on push to main?". Takes an explicit
    `mode` input:
    - manual (default): reads the version from Chart.yaml. If that version has not yet been
      tagged in git, outputs it as the release. If already tagged (no Chart.yaml bump was made),
      outputs empty and the release workflow short-circuits — no tag, no docker push, no helm upload.
      This preserves the exact behaviour repos expected before auto-semver was introduced.
    - auto: delegates to auto-semver to compute the next clean semver from conventional commits
      since the last tag. Use this for repos that keep a placeholder (e.g. 0.0.0-dev) in Chart.yaml
      and want CI to own versioning.
      
    Repos using the old system set mode: manual (or omit it, as that is the default). Repos opting
    in to the new system set mode: auto. The two systems are now fully isolated.
    
  docker-build
    Now always pushes two tags: the resolved version tag and the current branch name (e.g. `main`).
    This means every merge to main updates the `main` tag in Quay automatically, regardless of
    whether a new versioned release was triggered. Dev environments that track `main` receive updates
    on every merge without requiring any per-repo changes.
    
    Also fixes a YAML parse error introduced in the multi-tag implementation: a literal newline
    embedded in a bash string caused the line to appear at column 0 in the YAML literal block,
    which the GitHub Actions YAML parser interpreted as terminating the block early, making the
    entire action.yml unloadable. Fixed by using $'\n' instead of an embedded newline.
    
  gcp-helm-charts
    Adds a `chartMode` input. When set to `chart_ref`, skips version computation entirely and lets
    `helm package` read the version directly from each chart's own Chart.yaml. When empty (default),
    preserves existing behaviour: version is computed from git tags or passed through via chartVersion.